### PR TITLE
Add notebook overview markdown and document visualization outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ vsg_processing/
 
 > **Note**: The `de_analysis` directory is populated when the pipeline runs.
 
+The `prepare_data_and_plots.ipynb` notebook can be run end-to-end to execute the same processing script that powers the pipeline, regenerate the curated datasets, and build the Plotly scatter plot visualisations that are embedded within the VSGs web server.
+
 ## End-to-end workflow
 
 1. **Collect metadata** – `experiment_table.txt` captures SRA accessions, experimental groups, and run-level details. This file underpins the automation of control/treatment pairing and sample exclusion.

--- a/prepare_data_and_plots.ipynb
+++ b/prepare_data_and_plots.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data Preparation and Plot Generation\n\n",
+    "This notebook orchestrates the full preprocessing pipeline used by the VSGS web server. It:\n\n",
+    "- Loads the raw VSG expression data exported from the processing script.\n",
+    "- Cleans and enriches the dataset with annotations that the application displays.\n",
+    "- Generates interactive Plotly scatter plots that are embedded directly in the VSGS interface.\n\n",
+    "Run the notebook from top to bottom to reproduce the datasets and visualizations that power the site."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "0badf910-6980-42b2-a3a7-0b4fe97cc8a9",


### PR DESCRIPTION
## Summary
- add a descriptive overview markdown cell to `prepare_data_and_plots.ipynb`
- document in the README that the notebook regenerates processed data and Plotly scatter plots for the VSGS web server

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3aeaa1dac8331bb10d76ad5abcd61